### PR TITLE
[feature] UnsafeSkipCheck - skip the CSRF check.

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -35,6 +35,16 @@ func FailureReason(ctx context.Context, r *http.Request) error {
 	return nil
 }
 
+// UnsafeSkipCheck will skip the CSRF check for any requests using the provided
+// context.Context. This must be called before the CSRF middleware.
+//
+// Note: You should not set this without otherwise securing the request from
+// CSRF attacks. The primary use-case for this function is to turn off CSRF
+// checks for non-browser clients using authorization tokens against your API.
+func UnsafeSkipCheck(ctx context.Context) context.Context {
+	return context.WithValue(ctx, skipCheckKey, true)
+}
+
 // TemplateField is a template helper for html/template that provides an <input> field
 // populated with a CSRF token.
 //


### PR DESCRIPTION
- Skips the CSRF check when set for the given context/request.
- Addresses https://github.com/goji/ctx-csrf/issues/4

Example:

``` go
func CheckAuth(h goji.Handler) goji.Handler {
    fn := func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
        if r.Header.Get("Authorization") != "" {
            // Important that you capture the returned context, else it won't take effect.
            ctx = csrf.UnsafeSkipCheck(ctx)
            // Rest of your Authorization logic.
        }

        h.ServeHTTPC(ctx, w, r)
    }

    return goji.HandlerFunc(fn)
}

func main() {
    mux := goji.NewMux()
    // Make sure middleware that calls SkipCSRFCheck is called first.
    mux.UseC(CheckAuth)
    mux.UseC(csrf.Protect(key))

}
```
