### PR TITLE
Update for go 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ sudo: false
 
 matrix:
   include:
-    - go: 1.5
-    - go: 1.6
+    - go: 1.7
     - go: tip
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ matrix:
     - go: 1.7
     - go: tip
 
-install:
-  - go get golang.org/x/tools/cmd/vet
-
 script:
   - go get -t -v ./...
   - diff -u <(echo -n) <(gofmt -d .)

--- a/csrf.go
+++ b/csrf.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/gorilla/securecookie"
 )

--- a/csrf.go
+++ b/csrf.go
@@ -10,8 +10,6 @@ import (
 
 	"golang.org/x/net/context"
 
-	"goji.io"
-
 	"github.com/gorilla/securecookie"
 )
 
@@ -56,7 +54,7 @@ var (
 )
 
 type csrf struct {
-	h    goji.Handler
+	h    http.Handler
 	sc   *securecookie.SecureCookie
 	st   store
 	opts options
@@ -73,7 +71,7 @@ type options struct {
 	Secure        bool
 	RequestHeader string
 	FieldName     string
-	ErrorHandler  goji.Handler
+	ErrorHandler  http.Handler
 	CookieName    string
 }
 
@@ -115,7 +113,7 @@ type options struct {
 //	    // signup_form.tmpl just needs a {{ .csrfField }} template tag for
 //	    // csrf.TemplateField to inject the CSRF token into. Easy!
 //	    t.ExecuteTemplate(w, "signup_form.tmpl", map[string]interface{
-//	        csrf.TemplateTag: csrf.TemplateField(ctx, r),
+//		csrf.TemplateTag: csrf.TemplateField(ctx, r),
 //	    })
 //	    // We could also retrieve the token directly from csrf.Token(c, r) and
 //	    // set it in the request header - w.Header.Set("X-CSRF-Token", token)
@@ -128,13 +126,13 @@ type options struct {
 //	    // our CSRF protection requirements.
 //	}
 //
-func Protect(authKey []byte, opts ...Option) func(goji.Handler) goji.Handler {
-	return func(h goji.Handler) goji.Handler {
+func Protect(authKey []byte, opts ...Option) func(http.Handler) http.Handler {
+	return func(h http.Handler) http.Handler {
 		cs := parseOptions(h, opts...)
 
 		// Set the defaults if no options have been specified
 		if cs.opts.ErrorHandler == nil {
-			cs.opts.ErrorHandler = goji.HandlerFunc(unauthorizedHandler)
+			cs.opts.ErrorHandler = http.HandlerFunc(unauthorizedHandler)
 		}
 
 		if cs.opts.MaxAge < 1 {
@@ -181,11 +179,12 @@ func Protect(authKey []byte, opts ...Option) func(goji.Handler) goji.Handler {
 }
 
 // Implements goji.Handler for the csrf type.
-func (cs csrf) ServeHTTPC(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+func (cs csrf) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	// Skip the check if directed to. This should always be a bool.
 	if skip, ok := ctx.Value(skipCheckKey).(bool); ok {
 		if skip {
-			cs.h.ServeHTTPC(ctx, w, r)
+			cs.h.ServeHTTP(w, r)
 			return
 		}
 	}
@@ -202,7 +201,8 @@ func (cs csrf) ServeHTTPC(ctx context.Context, w http.ResponseWriter, r *http.Re
 		realToken, err = generateRandomBytes(tokenLength)
 		if err != nil {
 			ctx = setEnvError(ctx, err)
-			cs.opts.ErrorHandler.ServeHTTPC(ctx, w, r)
+			r = r.WithContext(ctx)
+			cs.opts.ErrorHandler.ServeHTTP(w, r)
 			return
 		}
 
@@ -210,7 +210,8 @@ func (cs csrf) ServeHTTPC(ctx context.Context, w http.ResponseWriter, r *http.Re
 		err = cs.st.Save(realToken, w)
 		if err != nil {
 			ctx = setEnvError(ctx, err)
-			cs.opts.ErrorHandler.ServeHTTPC(ctx, w, r)
+			r = r.WithContext(ctx)
+			cs.opts.ErrorHandler.ServeHTTP(w, r)
 			return
 		}
 	}
@@ -232,13 +233,15 @@ func (cs csrf) ServeHTTPC(ctx context.Context, w http.ResponseWriter, r *http.Re
 			referer, err := url.Parse(r.Referer())
 			if err != nil || referer.String() == "" {
 				ctx = setEnvError(ctx, ErrNoReferer)
-				cs.opts.ErrorHandler.ServeHTTPC(ctx, w, r)
+				r = r.WithContext(ctx)
+				cs.opts.ErrorHandler.ServeHTTP(w, r)
 				return
 			}
 
 			if sameOrigin(r.URL, referer) == false {
 				ctx = setEnvError(ctx, ErrBadReferer)
-				cs.opts.ErrorHandler.ServeHTTPC(ctx, w, r)
+				r = r.WithContext(ctx)
+				cs.opts.ErrorHandler.ServeHTTP(w, r)
 				return
 			}
 		}
@@ -247,7 +250,8 @@ func (cs csrf) ServeHTTPC(ctx context.Context, w http.ResponseWriter, r *http.Re
 		// ("unsafe") methods, call the error handler.
 		if realToken == nil {
 			ctx = setEnvError(ctx, ErrNoToken)
-			cs.opts.ErrorHandler.ServeHTTPC(ctx, w, r)
+			r = r.WithContext(ctx)
+			cs.opts.ErrorHandler.ServeHTTP(w, r)
 			return
 		}
 
@@ -257,7 +261,8 @@ func (cs csrf) ServeHTTPC(ctx context.Context, w http.ResponseWriter, r *http.Re
 		// Compare the request token against the real token
 		if !compareTokens(requestToken, realToken) {
 			ctx = setEnvError(ctx, ErrBadToken)
-			cs.opts.ErrorHandler.ServeHTTPC(ctx, w, r)
+			r = r.WithContext(ctx)
+			cs.opts.ErrorHandler.ServeHTTP(w, r)
 			return
 		}
 
@@ -267,12 +272,14 @@ func (cs csrf) ServeHTTPC(ctx context.Context, w http.ResponseWriter, r *http.Re
 	w.Header().Add("Vary", "Cookie")
 
 	// Call the wrapped handler/router on success
-	cs.h.ServeHTTPC(ctx, w, r)
+	r = r.WithContext(ctx)
+	cs.h.ServeHTTP(w, r)
 }
 
 // unauthorizedhandler sets a HTTP 403 Forbidden status and writes the
 // CSRF failure reason to the response.
-func unauthorizedHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+func unauthorizedHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	http.Error(w, fmt.Sprintf("%s - %s",
 		http.StatusText(http.StatusForbidden), FailureReason(ctx, r)),
 		http.StatusForbidden)

--- a/csrf_test.go
+++ b/csrf_test.go
@@ -8,7 +8,7 @@ import (
 
 	"goji.io/pat"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"goji.io"
 )

--- a/helpers.go
+++ b/helpers.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Token returns a masked CSRF token ready for passing into HTML template or

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -14,8 +14,9 @@ import (
 	"testing"
 	"text/template"
 
+	"context"
+
 	"goji.io/pat"
-	"golang.org/x/net/context"
 
 	"goji.io"
 )

--- a/options.go
+++ b/options.go
@@ -1,6 +1,6 @@
 package csrf
 
-import "goji.io"
+import "net/http"
 
 // Option describes a functional option for configuring the CSRF handler.
 type Option func(*csrf) error
@@ -70,7 +70,7 @@ func HttpOnly(h bool) Option {
 //
 // Note that a custom error handler can also access the csrf.Failure(c, r)
 // function to retrieve the CSRF validation reason from Goji's request context.
-func ErrorHandler(h goji.Handler) Option {
+func ErrorHandler(h http.Handler) Option {
 	return func(cs *csrf) error {
 		cs.opts.ErrorHandler = h
 		return nil
@@ -117,7 +117,7 @@ func setStore(s store) Option {
 
 // parseOptions parses the supplied options functions and returns a configured
 // csrf handler.
-func parseOptions(h goji.Handler, opts ...Option) *csrf {
+func parseOptions(h http.Handler, opts ...Option) *csrf {
 	// Set the handler to call after processing.
 	cs := &csrf{
 		h: h,

--- a/options_test.go
+++ b/options_test.go
@@ -1,15 +1,14 @@
 package csrf
 
 import (
+	"net/http"
 	"reflect"
 	"testing"
-
-	"goji.io"
 )
 
 // Tests that options functions are applied to the middleware.
 func TestOptions(t *testing.T) {
-	var h goji.Handler
+	var h http.Handler
 
 	age := 86400
 	domain := "goji.io"
@@ -27,7 +26,7 @@ func TestOptions(t *testing.T) {
 		Secure(false),
 		RequestHeader(header),
 		FieldName(field),
-		ErrorHandler(goji.HandlerFunc(errorHandler)),
+		ErrorHandler(http.HandlerFunc(errorHandler)),
 		CookieName(name),
 	}
 

--- a/store_test.go
+++ b/store_test.go
@@ -35,8 +35,8 @@ func (bs *brokenSaveStore) Save(realToken []byte, w http.ResponseWriter) error {
 func TestStoreCannotSave(t *testing.T) {
 	m := goji.NewMux()
 	bs := &brokenSaveStore{}
-	m.UseC(Protect(testKey, setStore(bs)))
-	m.HandleFuncC(pat.Get("/"), testHandler)
+	m.Use(Protect(testKey, setStore(bs)))
+	m.HandleFunc(pat.Get("/"), testHandler)
 
 	r, err := http.NewRequest("GET", "/", nil)
 	if err != nil {


### PR DESCRIPTION
The stdlib added a context type, and goji [has updated](https://github.com/goji/goji/commit/91164fbcb8275ef09c2d0d510707cca963db4378) to no longer
ship goji.Handler (same for UseC and HandleFuncC).

This PR also updates `.travis.yml` to bump the minimum version to 1.7 (as it's backwards-incompatible) and to correctly run tests (`go vet` is not go-installable anymore and ships with the minimum version by default).

This PR updates the ctx-csrf code to rely on stdlib types and functions. Tests pass, and I hope I got all this right!